### PR TITLE
Increased max-version to 26

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -28,7 +28,7 @@ Health is everything.]]></description>
 	<screenshot>https://dl.datenangebot.de/nc%20health/screenshots/v1.2.x/weight%20chart%20and%20data.png</screenshot>
 	<screenshot>https://dl.datenangebot.de/nc%20health/screenshots/v1.2.x/weight%20overview.png</screenshot>
 	<dependencies>
-        <nextcloud min-version="22" max-version="25"/>
+        <nextcloud min-version="22" max-version="26"/>
     </dependencies>
     <navigations>
         <navigation>


### PR DESCRIPTION
The app still works fine in Nextcloud 26.
This change just lets Nextcloud know that the app is supported and removes the  "untested app" status.